### PR TITLE
add circleci config for fixops deployment

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    working_directory: /home/circleci/stitchfix/algorithims-tour
+    docker:
+      - image: alpine:latest
+    environment:
+      CIRCLE_ARTIFACTS: public/
+    steps:
+      - checkout
+      - run:
+          name: make public dir
+          command: mkdir public/
+      - run:
+          name: copy assets
+          command: cp -rf * public/
+      - store_artifacts:
+          path: public/
+
+notify:
+ webhooks:
+   - url: https://fixops-service.stitchfix.com/webhooks/circleci


### PR DESCRIPTION
Adds a basic Circle CI configuration necessary for the deployment of algo-tours to fixops.