### PR TITLE
#2 fixed typo in 'State Machines' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1103,7 +1103,7 @@
     <h3>State Machines</h3>
     <section class="step">
       <p>
-        One of the ways we view this needs-anticipation problem (and related problems) is to consider the "state" of each client at each point in time. Are they a new client? Did they arrive via referral or on their own? Is their closet nearly full? Are they in a phase of building up their wardrobe after a life change? Or simply wanting to try something new? Depending on their state, they will likely have difference shipment cadences, different desires for email contact, etc.
+        One of the ways we view this needs-anticipation problem (and related problems) is to consider the "state" of each client at each point in time. Are they a new client? Did they arrive via referral or on their own? Is their closet nearly full? Are they in a phase of building up their wardrobe after a life change? Or simply wanting to try something new? Depending on their state, they will likely have different shipment cadences, different desires for email contact, etc.
       </p>
     </section>
 


### PR DESCRIPTION
I fixed a typo.  

**Before**

> Depending on their state, they will likely have difference shipment cadences, different desires for email contact, etc.

**After**

> Depending on their state, they will likely have different shipment cadences, different desires for email contact, etc.
