### PR TITLE
add cultivating algos header

### DIFF
--- a/css/multithreaded-main.css
+++ b/css/multithreaded-main.css
@@ -409,10 +409,10 @@ li.nav-tour, a.nav-tour {
   display: none;
 }
 
-@media only screen and (max-width : 737px) {
+@media only screen and (max-width : 1007px) {
 
   li.nav-tour, a.nav-tour {
-    display: none;
+    display: block;
   }
 
   li.nav-algorithms-tour, a.nav-algorithms-tour {

--- a/index.html
+++ b/index.html
@@ -63,14 +63,24 @@
         <img src="img/social/tweet-the-tour-sm.svg" alt="tweet the tour">
       </a>
     </li>
-    <li class="flex-4">
+    <li class="flex-4 nav-algorithms-tour">
       <a href="http://multithreaded.stitchfix.com/engineering" class="global-nav__item ">
         Engineering
       </a>
     </li>
-    <li class="flex-4">
+    <li class="flex-3 nav-tour">
+      <a href="http://multithreaded.stitchfix.com/engineering" class="global-nav__item ">
+        Eng
+      </a>
+    </li>
+    <li class="flex-4 nav-algorithms-tour">
       <a href="http://multithreaded.stitchfix.com/algorithms" class="global-nav__item ">
         Algorithms
+      </a>
+    </li>
+    <li class="flex-3 nav-tour">
+      <a href="http://multithreaded.stitchfix.com/algorithms" class="global-nav__item ">
+        Algo
       </a>
     </li>
     <li class="flex-3 nav-algorithms-tour">
@@ -81,6 +91,16 @@
     <li class="flex-3 nav-tour">
       <a href="http://algorithms-tour.stitchfix.com/" class="global-nav__item current">
         Tour
+      </a>
+    </li>
+    <li class="flex-3 nav-algorithms-tour">
+      <a href="http://cultivating-algos.stitchfix.com/" class="global-nav__item">
+        Cultivating Algos
+      </a>
+    </li>
+    <li class="flex-3 nav-tour">
+      <a href="http://cultivating-algos.stitchfix.com/" class="global-nav__item">
+        Garden
       </a>
     </li>
     <li class="flex-3">
@@ -105,17 +125,29 @@
       <img src="img/social/tweet-the-tour-sm.svg" alt="tweet the tour">
     </a>
     <div class="right">
-      <a href="http://multithreaded.stitchfix.com/engineering" class="global-nav__item ">
+      <a href="http://multithreaded.stitchfix.com/engineering" class="global-nav__item nav-algorithms-tour">
         Engineering
       </a>
-      <a href="http://multithreaded.stitchfix.com/algorithms" class="global-nav__item ">
+      <a href="http://multithreaded.stitchfix.com/engineering" class="global-nav__item nav-tour">
+        Eng
+      </a>
+      <a href="http://multithreaded.stitchfix.com/algorithms" class="global-nav__item nav-algorithms-tour">
         Algorithms
+      </a>
+      <a href="http://multithreaded.stitchfix.com/algorithms" class="global-nav__item nav-tour">
+        Algo
       </a>
       <a href="http://algorithms-tour.stitchfix.com" class="global-nav__item current nav-algorithms-tour">
         Algorithms Tour
       </a>
       <a href="http://algorithms-tour.stitchfix.com" class="global-nav__item current nav-tour">
         Tour
+      </a>
+      <a href="http://cultivating-algos.stitchfix.com" class="global-nav__item nav-algorithms-tour">
+        Cultivating Algos
+      </a>
+      <a href="http://cultivating-algos.stitchfix.com" class="global-nav__item nav-tour">
+        Garden
       </a>
       <a href="http://multithreaded.stitchfix.com/careers" class="global-nav__item ">
         Careers


### PR DESCRIPTION
(replicates https://github.com/stitchfix/algorithms-tour-private/pull/4)
Modifies the Algorithms Tour page header to match the new Cultivating Algos page header.

big screens:
<img width="1306" alt="algo-tour-big-screens" src="https://user-images.githubusercontent.com/13859152/75672328-76f7be80-5c78-11ea-9888-2c41ff739a8c.png">

small screens:
<img width="578" alt="algo-tour-small-screens" src="https://user-images.githubusercontent.com/13859152/75672348-7e1ecc80-5c78-11ea-8b76-fc34c0435b07.png">
